### PR TITLE
Add ability to specify custom request filters in config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 # Logs and databases #
 ######################
 *.log
+
+# Configs and tests#
+######################
+config/config.yaml

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,6 +4,7 @@
     # Format: "product reference": "directory name in framework"
     ks: 'ks'
     oae: 'oae'
+    bioiq: 'bioiq'
 # Directory listing for test data in use in the tests
 :directory:
     # Product for directory data

--- a/config/config.yaml.template
+++ b/config/config.yaml.template
@@ -1,0 +1,73 @@
+---
+# Products we currently support 
+:products:
+    # Format: "product reference": "directory name in framework"
+    ks: 'ks'
+    oae: 'oae'
+    bioiq: 'bioiq'
+:request_filters:
+    bioiq: 
+        :auth:
+            :username: 'example_user'
+            :password: 'example_pass'
+# Directory listing for test data in use in the tests
+:directory:
+    # Product for directory data
+    ks:
+        department_coc:
+            name: "Fisheries Department COC"
+            member:
+                username: "fishdptcoc1"
+                password: "fishdptcoc1"
+            chair:
+                username: "fishdptchair1"
+                password: "fishdptchair1"
+        department:
+            name: "Fisheries Department"
+            member:
+                username: "fishon1"
+                password: "fishon1"
+        division:
+            name: "Oceanography Division"
+        division_coc:
+            name: "Oceanography Division COC"
+            member:
+                username: "fishdvcoc1"
+                password: "fishdvcoc1"
+            chair:
+                username: "fishdvchair1"
+                password: "fishdvchair1"
+        college:
+            name: "The College of Ocean and Fishery Sciences"
+        college_coc:
+            name: "The College of Ocean and Fishery Sciences"
+            member:
+                username: "fishcollegec1"
+                password: "fishcollegec1"
+            chair:
+                username: "fishcollegechair9"
+                password: "fishcollegechair9"
+        senate:
+            name: "Senate Subcommittee on Curricula"
+            member:
+                username: "senate1"
+                password: "senate1"
+            chair:
+                username: "senatechair"
+                password: "senatechair"
+        atp:
+            name: "Class of 2012 Year 1"
+        lo:
+            name: "Performance LO"
+        users:
+            collaborator:
+                username: "fran"
+# Agent List
+:agents:
+    - 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:8.0.1) Gecko/20100101 Firefox/8.0.1'
+    # IE 7.0 - XP
+    - "Mozilla/5.0 (Windows; MSIE 7.0; Windows NT 6.0; en-US)"
+    # IE 6.0 - Vista
+    - "Mozilla/4.0 (Windows; MSIE 6.0; Windows NT 6.0)"
+    # FireFox 3.5.7 - Vista
+    - "Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US)"

--- a/lib/bioiq/common/authentication.rb
+++ b/lib/bioiq/common/authentication.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+
+# 
+# == Synopsis
+#
+# Authentication class containing all operations around app authentication
+#
+# Author:: Kyle Campos (mailto:kyle.campos@gmail.com)
+#
+
+class Authentication
+  
+  attr_accessor :request
+  
+  def initialize(request_obj)
+    @request = request_obj
+  end
+  
+  
+  # Load homepage
+  def homepage
+    @request.add('/')
+    @request.add('/stylesheets/marketing.css?1337924356')
+    @request.add('/javascripts/application.js?1257243198')
+  end
+  
+  # Screening programs tab
+  def screening_programs
+    @request.add('/employee-wellness-screening-programs')
+    @request.add('/stylesheets/marketing.css?1337924356')
+    @request.add('/javascripts/application.js?1257243198')
+  end
+  
+  # How BioIQ works tab
+  def how_bioiq_works
+    @request.add('/how-bioiq-health-screenings-work')
+    @request.add('/stylesheets/marketing.css?1337924356')
+    @request.add('/javascripts/application.js?1257243198')
+  end
+  
+  # What's included
+  def whats_included
+    @request.add('/employee-wellness-screening-program-features')
+    @request.add('/stylesheets/marketing.css?1337924356')
+    @request.add('/javascripts/application.js?1257243198')
+  end
+  
+  # Test kits tab
+  def test_kits
+    @request.add('GET /employee-health-wellness-tests HTTP/1.1')
+    @request.add('GET /themes/bioiq/stylesheets/partner.css?1337967627 HTTP/1.1')
+    @request.add('GET /javascripts/application.js?1337924356 HTTP/1.1')
+  end
+  
+  # Register a new user
+  def register(username, opts={})
+    
+    defaults = {
+      :load_homepage => true,
+    }
+    
+    opts = defaults.merge(opts)
+    
+    self.homepage if(opts[:load_homepage])
+    
+    @request.add_thinktime(5)
+    
+    @request.add('GET /signup/path HTTP/1.1')
+    @request.add('GET /themes/bioiq/stylesheets/partner.css?1337967627 HTTP/1.1')
+    @request.add('GET /javascripts/application.js?1337924356 HTTP/1.1')
+    
+    
+  end
+  
+end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -22,7 +22,7 @@ class AutoConfig
     :tsung_log_level, :secondary_context, :tsung_element, :sessions_element, :sso, :thinktime, :import_files, :ssl
     
   attr_reader :product, :suite, :directory, :config_setup, :config_dir, :suite_base_dir, :suite_dir, :test_base_dir, :test_dir, :lib_base_dir,
-    :import_base_dir, :import_dir, :data_base_dir, :data_dir
+    :import_base_dir, :import_dir, :data_base_dir, :data_dir, :request_filters
 
   
   def initialize
@@ -279,6 +279,16 @@ class AutoConfig
     @product
   end
   
+  # Set request filters scoped by product
+  def request_filters
+    if(self.config_setup[:request_filters])
+      @request_filters = (self.config_setup[:request_filters][@product] ? self.config_setup[:request_filters][@product] : {})
+    else
+      @request_filters = {}
+    end
+    @request_filters
+  end
+  
   # Set suite for this particular run
   def suite=(name)
     @suite = (validate_suite(name) ? name : nil)
@@ -515,7 +525,7 @@ class AutoConfig
     
     self.import_files = {}
     
-    Dir.foreach(@import_dir) do |file|
+    File.directory? @import_dir and Dir.foreach(@import_dir) do |file|
       next if (file !~ /.+\.format$/) #skip if anything other than a format file
       
       csv_file = file.sub('.format', '.csv')

--- a/lib/tsung-api.rb
+++ b/lib/tsung-api.rb
@@ -251,7 +251,11 @@ class Requests < Transaction
     http = req.add_element('http', opts)
     
     # Write basic authentication for request if necessary
-    http.add_element('www_authenticate', {'userid' => auth_opt[:auth][:username], 'passwd' => auth_opt[:auth][:password]}) if(!auth_opt[:auth].empty?)
+    if(self.config.request_filters[:auth])
+      http.add_element('www_authenticate', {'userid' => self.config.request_filters[:auth][:username], 'passwd' => self.config.request_filters[:auth][:password]})
+    elsif(!auth_opt[:auth].empty?)
+      http.add_element('www_authenticate', {'userid' => auth_opt[:auth][:username], 'passwd' => auth_opt[:auth][:password]})
+    end
     
     # BUG - need a way to dynamically ingest custome headers per product
     # BUG - hardcoded to first app server

--- a/suites/bioiq/browse
+++ b/suites/bioiq/browse
@@ -1,0 +1,3 @@
+# Format: test_name,probability
+# Example: login.rb,100
+browse.rb,100

--- a/tests/bioiq/browse.rb
+++ b/tests/bioiq/browse.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+#
+# == Description
+#
+# Browse around the website unauthenticated
+#
+# === Issues
+#
+# 
+
+require 'drb'
+config = DRbObject.new nil, "druby://localhost:#{ENV['DRB_PORT']}"
+
+require config.lib_base_dir + "/tsung-api.rb"
+require config.lib_base_dir + "/#{config.product}/common/authentication.rb"
+
+
+# Test info - default test case setup
+test = File.basename(__FILE__)
+probability = config.tests[test]
+config.log.info_msg("Test: #{test}")
+config.log.info_msg("Probability: #{config.tests[test]}")
+
+# Create session
+sesh = Session.new(config, 'customize_dashbaord', probability)
+
+# Login
+username = '%%_username%%'
+password = '%%_user_password%%'
+
+browse_txn = sesh.add_transaction("home_browse")
+browse_req = browse_txn.add_requests
+config.log.info_msg("#{test}: Browsing website")
+browse = Authentication.new(browse_req)
+
+browse.homepage
+browse.screening_programs
+browse.how_bioiq_works
+browse.whats_included
+browse.test_kits
+browse.register('fakeuser', {:load_homepage => false})


### PR DESCRIPTION
Now you can specify request filters on a per product basis in the config.yaml. This is useful for when you need to add things like http auth to every request for a given product.
